### PR TITLE
Add :data_bag_keyfile attribute to the LWRP.

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ and wildcard-bundle.crt (CA Root chain)
 The LWRP resource attributes are as follows.
 
   * data\_bag - Data bag index to search, defaults to certificates
+  * data\_bag\_keyfile - Pathname to the file containing the databag encryption key (if ommitted, Chef's default keyfile will be used)
   * search\_id - Data bag id to search for, defaults to provider name
   * cert\_path - Top-level SSL directory, defaults to vendor specific location
   * cert\_file - The basename of the x509 certificate, defaults to {node.fqdn}.pem

--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -22,7 +22,8 @@ def whyrun_supported?
 end
 
 action :create do
-  ssl_item = Chef::EncryptedDataBagItem.load(new_resource.data_bag, new_resource.search_id)
+  databag_key = Chef::EncryptedDataBagItem.load_secret(new_resource.data_bag_keyfile)
+  ssl_item = Chef::EncryptedDataBagItem.load(new_resource.data_bag, new_resource.search_id, databag_key)
 
   cert_directory_resource "certs"
   cert_directory_resource "private", :private => true

--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -27,6 +27,7 @@ actions :create
 # :data_bag is the Data Bag to search.
 # :search_id is the Data Bag object you wish to search.
 attribute :data_bag, :kind_of => String, :default => "certificates"
+attribute :data_bag_keyfile, :kind_of => String, :default => nil
 attribute :search_id, :kind_of => String, :name_attribute => true 
 
 # :cert_file is the filename for the managed certificate.


### PR DESCRIPTION
Here is a rework of pull request #3 which allows an alternate keyfile to be specified. 
This time, the LWRP was extended to include a 'data_bag_keyfile' attribute which 
can specify a filename where the databag encryption key is stored. If the attribute is
not specified, the Chef default databag keyfile behavior is used (e.g. /etc/chef/encrypted_data_bag_secret).
