### PR TITLE
Do not hard code default data_bag_secret path

### DIFF
--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -28,7 +28,7 @@ actions :create
 # :data_bag_secret is the path to the file with the data bag secret
 # :search_id is the Data Bag object you wish to search.
 attribute :data_bag, :kind_of => String, :default => "certificates"
-attribute :data_bag_secret, :kind_of => String, :default => "/etc/chef/encrypted_data_bag_secret"
+attribute :data_bag_secret, :kind_of => String, :default => nil
 attribute :search_id, :kind_of => String, :name_attribute => true 
 
 # :cert_file is the filename for the managed certificate.


### PR DESCRIPTION
Default to `nil` which will use `encrypted_data_bag_secret` from Chef configuration (which indeed defaults to _/etc/chef/encrypted_data_bag_secret_).

Hard coding the default breaks for example Vagrant and knife-solo setups that upload the key to a different path.
