### PR TITLE
Fix typo in "manage" resource definitions

### DIFF
--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -49,7 +49,7 @@ end
 attribute :cert_file, :kind_of => String, :default => "#{node['fqdn']}.pem"
 attribute :key_file, :kind_of => String, :default => "#{node['fqdn']}.key"
 attribute :chain_file, :kind_of => String, :default => "#{node['hostname']}-bundle.crt"
-attribute :create_subfolders, :kind_of => [ TrueClass, FlaseClass ], :default => true
+attribute :create_subfolders, :kind_of => [ TrueClass, FalseClass ], :default => true
 
 # The owner and group of the managed certificate and key
 attribute :owner, :kind_of => String, :default => "root"


### PR DESCRIPTION
v0.2.2 breaks the LWRP as there is a typo in `FalseClass`.

IMHO the strict type validation there is not even needed as normal truthy/falsy handling should be fine, but your cookbook. ;)

By the way, new features require a minor version number bump according to [SemVer](http://semver.org/). I've found it a good practice to try to follow SemVer also on cookbook versioning.
