### PR TITLE
Add ChefSpec matcher

### DIFF
--- a/libraries/matchers.rb
+++ b/libraries/matchers.rb
@@ -1,0 +1,7 @@
+if defined?(ChefSpec)
+  ChefSpec::Runner.define_runner_method :certificate_manage
+
+  def create_certificate_manage(resource)
+    ChefSpec::Matchers::ResourceMatcher.new(:certificate_manage, :create, resource)
+  end
+end


### PR DESCRIPTION
Adds a simple ChefSpec matcher, which allows for tests like this:

<pre>
  expect(runner).to create_certificate_manage('www.example.com').with(
    cert_path: '/path/to/certs',
    owner: 'username',
    group: 'groupname',
    key_file: "www.example.com.key",
    cert_file: "www.example.com.combined.crt",
    create_subfolders: false,
    nginx_cert: true
  )
</pre>
