### PR TITLE
gitignore: ignore a bit more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,25 @@
-*.lock
-metadata.json
-.kitchen/
-.kitchen.local.yml
+/metadata.json
+
+# Test Kitchen
+/.kitchen/
+/.kitchen.local.yml
+
+# CTags files
+/tags
+
+# Bundler
+/Gemfile.lock
+/bin/
+/.bundle/
+
+# Berkshelf
+/Berksfile.lock
+/.vagrant/
+
+# Editor temp files
+*~
+*#
+.#*
+\#*#
+.*.sw[a-z]
+*.un~


### PR DESCRIPTION
Just a minor cleanup of the `.gitignore` to include some common things such an
CTags, other bundler items (like `.bundle/`).
