### PR TITLE
Enable use_inline_resources

### DIFF
--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -21,6 +21,8 @@ def whyrun_supported?
   true
 end
 
+use_inline_resources
+
 action :create do
   ssl_secret = Chef::EncryptedDataBagItem.load_secret(new_resource.data_bag_secret)
   ssl_item = Chef::EncryptedDataBagItem.load(new_resource.data_bag, new_resource.search_id, ssl_secret)


### PR DESCRIPTION
This fixes notification for calling resources

When calling `certificate_manage`, the caller doesn't get notified properly. 
I restart nginx automatically when a certificate is changed, and the nginx service was not notified
