### PR TITLE
Updated readme links

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Requirements
 
 You do need to prepare an encrypted data bag, containing the certificates,
 private keys, and CA bundles you wish to deploy to servers with the LWRP.
-I used Joshua Timberman's [blog post](https://jtimberman.posterous.com/64227128),
-and the Opscode [Wiki documentation](http://wiki.opscode.com/display/chef/Encrypted+Data+Bags)
+I used Joshua Timberman's [blog post](http://jtimberman.housepub.org/blog/2011/08/06/encrypted-data-bag-for-postfix-sasl-authentication/),
+and the Opscode [Wiki documentation](https://wiki.opscode.com/display/chef10/Encrypted+Data+Bags)
 as a reference in creating this cookbook.
 
 First, create a **data bag secret** as follows.  You need to manually copy


### PR DESCRIPTION
The two readme links are dead. 
1. Joshua's blog has been moved - I think I've found its new resting place.
2. The opscode docs seem to be in constant flux - I think you wanted chef10 version that referenced Joshua's blog. However possibly you wanted, [Chef 11 though that has turned data-bags into a one page topic.](http://docs.opscode.com/chef/essentials_data_bags.html)
