### PR TITLE
Make cookbook backwards compatible with Ruby 1.X

### DIFF
--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -40,10 +40,10 @@ action :create do
     if new_resource.combined_file
       cert_file_resource new_resource.cert_file,
                          "#{ssl_item['cert']}\n#{ssl_item['chain']}\n#{ssl_item['key']}",
-                         private: true
+                         :private => true
     elsif new_resource.create_subfolders
       cert_directory_resource 'certs'
-      cert_directory_resource 'private', private: true
+      cert_directory_resource 'private', :private => true
 
       if new_resource.nginx_cert
         cert_file_resource "certs/#{new_resource.cert_file}",  "#{ssl_item['cert']}\n#{ssl_item['chain']}"
@@ -51,7 +51,7 @@ action :create do
         cert_file_resource "certs/#{new_resource.cert_file}",  ssl_item['cert']
         cert_file_resource "certs/#{new_resource.chain_file}", ssl_item['chain']
       end
-      cert_file_resource "private/#{new_resource.key_file}", ssl_item['key'], private: true
+      cert_file_resource "private/#{new_resource.key_file}", ssl_item['key'], :private => true
     else
       if new_resource.nginx_cert
         cert_file_resource new_resource.cert_file,  "#{ssl_item['cert']}\n#{ssl_item['chain']}"
@@ -59,7 +59,7 @@ action :create do
         cert_file_resource new_resource.cert_file,  ssl_item['cert']
         cert_file_resource new_resource.chain_file, ssl_item['chain']
       end
-      cert_file_resource new_resource.key_file, ssl_item['key'], private: true
+      cert_file_resource new_resource.key_file, ssl_item['key'], :private => true
     end
   end
 end
@@ -81,7 +81,7 @@ def cert_file_resource(path, content, options = {})
     owner new_resource.owner
     group new_resource.group
     mode(options[:private] ? 00640 : 00644)
-    variables file_content: content
+    variables :file_content => content
     only_if { content }
   end
   new_resource.updated_by_last_action(true) if r.updated_by_last_action?

--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -27,10 +27,10 @@ actions :create
 # :data_bag is the Data Bag to search.
 # :data_bag_secret is the path to the file with the data bag secret
 # :search_id is the Data Bag object you wish to search.
-attribute :data_bag, kind_of: String, default: 'certificates'
-attribute :data_bag_secret, kind_of: String, default: Chef::Config['encrypted_data_bag_secret']
-attribute :search_id, kind_of: String, name_attribute: true
-attribute :ignore_missing, kind_of: [TrueClass, FalseClass], default: false
+attribute :data_bag, :kind_of => String, :default => 'certificates'
+attribute :data_bag_secret, :kind_of => String, :default => Chef::Config['encrypted_data_bag_secret']
+attribute :search_id, :kind_of => String, :name_attribute => true
+attribute :ignore_missing, :kind_of => [TrueClass, FalseClass], :default => false
 
 # :ngnix_cert is a PEM which combine host cert and CA trust chain for nginx.
 # :combined_file is a PEM which combine certs and keys in one file, for things such as haproxy.
@@ -41,24 +41,24 @@ attribute :ignore_missing, kind_of: [TrueClass, FalseClass], default: false
 # :create_subfolders will automatically create certs and private sub-folders
 case node['platform_family']
 when 'rhel'
-  attribute :cert_path, kind_of: String, default: '/etc/pki/tls'
+  attribute :cert_path, :kind_of => String, :default => '/etc/pki/tls'
 when 'debian'
-  attribute :cert_path, kind_of: String, default: '/etc/ssl'
+  attribute :cert_path, :kind_of => String, :default => '/etc/ssl'
 when 'smartos'
-  attribute :cert_path, kind_of: String, default: '/opt/local/etc/openssl'
+  attribute :cert_path, :kind_of => String, :default => '/opt/local/etc/openssl'
 else
-  attribute :cert_path, kind_of: String, default: '/etc/ssl'
+  attribute :cert_path, :kind_of => String, :default => '/etc/ssl'
 end
-attribute :nginx_cert, kind_of: [TrueClass, FalseClass], default: false
-attribute :combined_file, kind_of: [TrueClass, FalseClass], default: false
-attribute :cert_file, kind_of: String, default: "#{node['fqdn']}.pem"
-attribute :key_file, kind_of: String, default: "#{node['fqdn']}.key"
-attribute :chain_file, kind_of: String, default: "#{node['hostname']}-bundle.crt"
-attribute :create_subfolders, kind_of: [TrueClass, FalseClass], default: true
+attribute :nginx_cert, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :combined_file, :kind_of => [TrueClass, FalseClass], :default => false
+attribute :cert_file, :kind_of => String, :default => "#{node['fqdn']}.pem"
+attribute :key_file, :kind_of => String, :default => "#{node['fqdn']}.key"
+attribute :chain_file, :kind_of => String, :default => "#{node['hostname']}-bundle.crt"
+attribute :create_subfolders, :kind_of => [TrueClass, FalseClass], :default => true
 
 # The owner and group of the managed certificate and key
-attribute :owner, kind_of: String, default: 'root'
-attribute :group, kind_of: String, default: 'root'
+attribute :owner, :kind_of => String, :default => 'root'
+attribute :group, :kind_of => String, :default => 'root'
 
 # Cookbook to search for blank.erb template
-attribute :cookbook, kind_of: String, default: 'certificate'
+attribute :cookbook, :kind_of => String, :default => 'certificate'


### PR DESCRIPTION
Switch from `variable: value` to `:variable => value` to make the cookbook
compatible with Ruby 1.X.
