### PR TITLE
Allow testing without a version

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'eric.wolfe@gmail.com'
 license 'Apache 2.0'
 description 'Installs/Configures certificates, private keys, CA root bundles from encrypted data bags.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version IO.read(File.join(File.dirname(__FILE__), 'VERSION')) || '0.0.1'
+version IO.read(File.join(File.dirname(__FILE__), 'VERSION')) rescue '0.0.1'
 %w( amazon centos debian fedora redhat oracle scientific ubuntu smartos ).each do |os|
   supports os
 end


### PR DESCRIPTION
A potential compromise solution to #31? When `VERSION` file is missing it fails gracefully allowing kitchen tests to run and complete successfully.

This is just a suggestion PR really, if this gets in the way of the build process or is otherwise no good, please go ahead and close it.

Cheers!
