### PR TITLE
Update to support chef-vault version 2.0.0

### DIFF
--- a/.kitchen.fail.yml
+++ b/.kitchen.fail.yml
@@ -1,5 +1,7 @@
 ---
-driver_plugin: vagrant
+driver:
+  name: vagrant
+
 provisioner:
   name: chef_zero
 

--- a/.kitchen.fail.yml
+++ b/.kitchen.fail.yml
@@ -6,10 +6,14 @@ provisioner:
   name: chef_zero
 
 platforms:
-- name: ubuntu-12.04
-- name: ubuntu-10.04
-- name: centos-6.6
-- name: centos-5.11
+  - name: ubuntu-14.04
+  - name: ubuntu-12.04
+  - name: ubuntu-10.04
+  - name: centos-7.2
+  - name: centos-6.8
+  - name: centos-5.11
+  - name: fedora-21
+  - name: fedora-22
 
 # This suite should always fail, because we do not
 # support vault on chef-solo.  Keeping this kitchen file

--- a/.kitchen.fail.yml
+++ b/.kitchen.fail.yml
@@ -19,15 +19,15 @@ platforms:
 # support vault on chef-solo.  Keeping this kitchen file
 # separate until there is some chef failure verifier
 suites:
-- name: vault
-  data_bag_path: "test/integration/vault/data_bags"
-  run_list: ["recipe[certificate::manage_by_attributes]"]
-  attributes:
-    certificate: [
-      test: {
-        data_bag_type: 'vault',
-        nginx_cert: true,
-        cert_file: "test.pem",
-        key_file: "test.key"
-      }
-    ]
+  - name: vault
+    data_bag_path: "test/integration/vault/data_bags"
+    run_list:
+      - recipe[certificate::manage_by_attributes]
+    attributes:
+      certificate:
+        test: {
+          data_bag_type: 'vault',
+          nginx_cert: true,
+          cert_file: "test.pem",
+          key_file: "test.key"
+        }

--- a/.kitchen.fail.yml
+++ b/.kitchen.fail.yml
@@ -1,5 +1,7 @@
 ---
 driver_plugin: vagrant
+provisioner:
+  name: chef_zero
 
 platforms:
 - name: ubuntu-12.04

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -1,36 +1,44 @@
 ---
-driver_plugin: vagrant
+driver:
+  name: vagrant
+
+provisioner:
+  name: chef_solo
 
 platforms:
-- name: ubuntu-12.04
-- name: ubuntu-10.04
-- name: centos-6.6
-- name: centos-5.11
-- name: fedora-21
+  - name: ubuntu-14.04
+  - name: ubuntu-12.04
+  - name: ubuntu-10.04
+  - name: centos-7.2
+  - name: centos-6.8
+  - name: centos-5.11
+  - name: fedora-21
+  - name: fedora-22
 
 suites:
-- name: default
-  data_bag_path: "test/integration/default/data_bags"
-  encrypted_data_bag_secret_key_path: "test/integration/default/encrypted_data_bag_secret"
-  run_list: ["recipe[certificate::manage_by_attributes]"]
-  attributes:
-    certificate: [
-      test: {
-        data_bag_type: 'encrypted',
-        nginx_cert: true,
-        cert_file: "test.pem",
-        key_file: "test.key"
-      }
-    ]
-- name: unencrypted
-  data_bag_path: "test/integration/unencrypted/data_bags"
-  run_list: ["recipe[certificate::manage_by_attributes]"]
-  attributes:
-    certificate: [
-      test: {
-        data_bag_type: 'unencrypted',
-        nginx_cert: true,
-        cert_file: "test.pem",
-        key_file: "test.key"
-      }
-    ]
+  - name: default
+    data_bag_path: "test/integration/default/data_bags"
+    encrypted_data_bag_secret_key_path: "test/integration/default/encrypted_data_bag_secret"
+    run_list:
+     - recipe[certificate::manage_by_attributes]
+    attributes:
+      certificate:
+        test: {
+          data_bag_type: 'encrypted',
+          nginx_cert: true,
+          cert_file: "test.pem",
+          key_file: "test.key"
+        }
+
+  - name: unencrypted
+    data_bag_path: "test/integration/unencrypted/data_bags"
+    run_list:
+      - recipe[certificate::manage_by_attributes]
+    attributes:
+      certificate:
+        test: {
+          data_bag_type: 'unencrypted',
+          nginx_cert: true,
+          cert_file: "test.pem",
+          key_file: "test.key"
+        }

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,11 +1,15 @@
 Encoding:
-  Enabled: False
+  Enabled: false
 LineLength:
   Max: 200
 HashSyntax:
-  Enabled: False
+  Enabled: false
 Style/RescueModifier:
   Enabled: false
+RedundantSelf:
+  Exclude:
+    - 'recipes/manage_by_attributes.rb'
 AllCops:
   Exclude:
   - '.kitchen/*'
+  - 'providers/manage.rb'

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,12 @@
 language: ruby
 rvm:
-  - 2.1.5 
-install: bundle install --without integration 
+  - 2.1.9
+  - 2.2.5
+  - 2.3.1
+
+install: bundle install --without integration
+
 script:
- - bundle exec rake
+  - bundle exec rspec --default-path spec
+  - bundle exec foodcritic -f any .
+  - bundle exec rubocop

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: ruby
 rvm:
-  - 2.1.9
   - 2.2.5
   - 2.3.1
 

--- a/Berksfile
+++ b/Berksfile
@@ -1,3 +1,3 @@
-source 'https://supermarket.getchef.com'
+source 'https://supermarket.chef.io'
 
 metadata

--- a/metadata.rb
+++ b/metadata.rb
@@ -7,6 +7,8 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version IO.read(File.join(File.dirname(__FILE__), 'VERSION')) rescue '0.0.1'
 %w( amazon centos debian fedora redhat oracle scientific ubuntu smartos ).each do |os|
   supports os
+source_url 'https://github.com/atomic-penguin/cookbook-certificate.git'
+issues_url 'https://github.com/atomic-penguin/cookbook-certificate/issues'
 end
 
 depends 'chef-vault'

--- a/metadata.rb
+++ b/metadata.rb
@@ -13,3 +13,13 @@ rescue
 end
 
 depends 'chef-vault', '~> 2.0'
+
+supports amazon # <- Not tested
+supports centos, '>= 5.11' # Tested
+supports debian, '>= 7.8' # <- Assumed to work
+supports fedora, '>= 22' # Tested
+supports oracle # <- Not tested
+supports redhat, '>= 5.11' # <- Assumed to work
+supports scientific, '>= 5' # <- Assummed to work
+supports smartos # <- Not tested
+supports ubuntu, '>= 10.04' # Tested

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,11 +4,12 @@ maintainer_email 'eric.wolfe@gmail.com'
 license 'Apache 2.0'
 description 'Installs/Configures certificates, private keys, CA root bundles from encrypted data bags.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version IO.read(File.join(File.dirname(__FILE__), 'VERSION')) rescue '0.0.1'
-%w( amazon centos debian fedora redhat oracle scientific ubuntu smartos ).each do |os|
-  supports os
 source_url 'https://github.com/atomic-penguin/cookbook-certificate.git'
 issues_url 'https://github.com/atomic-penguin/cookbook-certificate/issues'
+begin
+  version IO.read(File.join(File.dirname(__FILE__), 'VERSION'))
+rescue
+  '0.0.1'
 end
 
 depends 'chef-vault'

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,4 +12,4 @@ rescue
   '0.0.1'
 end
 
-depends 'chef-vault'
+depends 'chef-vault', '~> 2.0'

--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -58,7 +58,7 @@ action :create do
         end
       end
   else
-    fail "Unsupported data bag type #{new_resource.data_bag_type}"
+    raise "Unsupported data bag type #{new_resource.data_bag_type}"
   end
 
   next if ssl_item.nil?
@@ -66,13 +66,13 @@ action :create do
   if new_resource.combined_file
     cert_file_resource ::File.join(new_resource.cert_path, new_resource.cert_file),
                        "#{ssl_item['cert']}\n#{ssl_item['chain']}\n#{ssl_item['key']}",
-                       :private => true
+                       private: true
     next
   end
 
   if new_resource.create_subfolders
     cert_directory_resource 'certs'
-    cert_directory_resource 'private', :private => true
+    cert_directory_resource 'private', private: true
   end
 
   if new_resource.nginx_cert
@@ -81,7 +81,7 @@ action :create do
     cert_file_resource new_resource.certificate, ssl_item['cert']
     cert_file_resource new_resource.chain, ssl_item['chain']
   end
-  cert_file_resource new_resource.key, ssl_item['key'], :private => true
+  cert_file_resource new_resource.key, ssl_item['key'], private: true
 end
 
 def cert_directory_resource(dir, options = {})
@@ -101,7 +101,7 @@ def cert_file_resource(path, content, options = {})
     owner new_resource.owner
     group new_resource.group
     mode(options[:private] ? 00640 : 00644)
-    variables :file_content => content
+    variables file_content: content
     only_if { content }
     sensitive new_resource.sensitive if respond_to?(:sensitive)
   end

--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -47,9 +47,8 @@ action :create do
     Chef::Application.fatal!('Vault type encryption not supported with chef-solo') if Chef::Config['solo']
     ssl_item =
       begin
-        chef_gem 'chef-vault'
-        require 'chef-vault'
-        ChefVault::Item.load(new_resource.data_bag, new_resource.search_id)
+        include_recipe 'chef-vault'
+        chef_vault_item(new_resource.data_bag, new_resource.search_id)
       rescue ChefVault::Exceptions::KeysNotFound, ChefVault::Exceptions::SecretDecryption
         begin
           Chef::DataBagItem.load(new_resource.data_bag, new_resource.search_id)

--- a/recipes/manage_by_attributes.rb
+++ b/recipes/manage_by_attributes.rb
@@ -20,7 +20,7 @@
 # limitations under the License.
 
 node['certificate'].each do |cert|
-  cert.each_pair do |id, opts|
+  cert.each_slice(2) do |id, opts|
     Chef::Log.debug "Create certs #{id} from attribute"
     certificate_manage id do
       action :create

--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -31,7 +31,7 @@ actions :create
 # :search_id is the Data Bag object you wish to search.
 attribute :data_bag, :kind_of => String, :default => 'certificates'
 attribute :data_bag_secret, :kind_of => String, :default => Chef::Config['encrypted_data_bag_secret']
-attribute :data_bag_type, :kind_of => String, :equal_to => ['unencrypted', 'encrypted', 'vault'], :default => 'encrypted'
+attribute :data_bag_type, :kind_of => String, :equal_to => %w(unencrypted encrypted vault), :default => 'encrypted'
 attribute :search_id, :kind_of => String, :name_attribute => true
 attribute :ignore_missing, :kind_of => [TrueClass, FalseClass], :default => false
 


### PR DESCRIPTION
Attempting to push a new version of the `certificate` cookbook so it will support `chef-vault` version `2.0.0`

I am also doing some linting/cleanup and improving the tests available to verify the code base either by kitchen or TravisCI.

Would be nice to set a future goal of converting this cookbook to a full resource cookbook (`3.0.0`) whenever someone has time. Thanks in advance.
