### PR TITLE
Add LWRP property to set key file to 0600 instead of 0640 when strict…

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ The LWRP resource attributes are as follows.
   * `group` - The file group owner, defaults to root
   * `cookbook` - The cookbook containing the erb template, defaults to certificate
   * `create_subfolders` - Enable/disable auto-creation of private/certs subdirectories.  Defaults to true
+  * `strict_key_perms` - If `true`, sets the key file to 600 instead of 640 for programs with strict key permission checking. Defaults to `false`
 
 #### providers
 

--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -67,7 +67,7 @@ action :create do
   if new_resource.combined_file
     cert_file_resource ::File.join(new_resource.cert_path, new_resource.cert_file),
                        "#{ssl_item['cert']}\n#{ssl_item['chain']}\n#{ssl_item['key']}",
-                       :private => true
+                       :private => true, :strict => new_resource.strict_key_perms
     next
   end
 
@@ -82,7 +82,7 @@ action :create do
     cert_file_resource new_resource.certificate, ssl_item['cert']
     cert_file_resource new_resource.chain, ssl_item['chain']
   end
-  cert_file_resource new_resource.key, ssl_item['key'], :private => true
+  cert_file_resource new_resource.key, ssl_item['key'], :private => true, :strict => new_resource.strict_key_perms
 end
 
 def cert_directory_resource(dir, options = {})
@@ -101,7 +101,7 @@ def cert_file_resource(path, content, options = {})
     cookbook new_resource.cookbook
     owner new_resource.owner
     group new_resource.group
-    mode(options[:private] ? 00640 : 00644)
+    mode(options[:private] ? (options[:strict] ? 00600 : 00640) : 00644)
     variables :file_content => content
     only_if { content }
     sensitive new_resource.sensitive if respond_to?(:sensitive)

--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -62,6 +62,7 @@ attribute :create_subfolders, :kind_of => [TrueClass, FalseClass], :default => t
 # The owner and group of the managed certificate and key
 attribute :owner, :kind_of => String, :default => 'root'
 attribute :group, :kind_of => String, :default => 'root'
+attribute :strict_key_perms, :kind_of => [TrueClass, FalseClass], :default => false
 
 # Cookbook to search for blank.erb template
 attribute :cookbook, :kind_of => String, :default => 'certificate'


### PR DESCRIPTION
Added LWRP boolean property that defaults to _false_ called **'strict_key_perms'**, that, when set to _true_, will set the key's mode to 0600 instead of 0640. This allows the cookbook to be used for applications that perform strict permissions checking on the key file (postgres, etc).