### PR TITLE
Fix only_if warning with recent chef version #55

### DIFF
--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -103,7 +103,7 @@ def cert_file_resource(path, content, options = {})
     group new_resource.group
     mode(options[:private] ? 00640 : 00644)
     variables :file_content => content
-    only_if { content }
+    not_if { content.nil? }
     sensitive new_resource.sensitive if respond_to?(:sensitive)
   end
   new_resource.updated_by_last_action(true) if r.updated_by_last_action?


### PR DESCRIPTION
Fix the following chef warning, first reported in #55:

```
* template[/etc/ssl/example-com.pem] action create[2017-08-17T14:01:41+00:00] WARN: only_if block for template[/etc/ssl/example-com.pem] returned a string, did you mean to run a command?
```