### PR TITLE
Add new data_bag_type hashicorp-vault.

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -5,8 +5,11 @@ license 'Apache 2.0'
 description 'Installs/Configures certificates, private keys, CA root bundles from encrypted data bags.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version IO.read(File.join(File.dirname(__FILE__), 'VERSION')) rescue '0.0.1'
+chef_version '>= 12.8'
 %w( amazon centos debian fedora redhat oracle scientific ubuntu smartos ).each do |os|
   supports os
 end
 
 depends 'chef-vault'
+
+gem 'vault'

--- a/providers/manage.rb
+++ b/providers/manage.rb
@@ -58,6 +58,16 @@ action :create do
           nil
         end
       end
+  when 'hashicorp-vault'
+    ssl_item =
+      begin
+        require 'vault'
+        vault_client = Vault::Client.new(address: new_resource.hashicorp_vault_address, token: new_resource.hashicorp_vault_token)
+        vault_client.logical.read("#{new_resource.search_id}").data
+      rescue => e
+        raise e unless new_resource.ignore_missing
+        nil
+      end
   else
     fail "Unsupported data bag type #{new_resource.data_bag_type}"
   end

--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -31,7 +31,7 @@ actions :create
 # :search_id is the Data Bag object you wish to search.
 attribute :data_bag, :kind_of => String, :default => 'certificates'
 attribute :data_bag_secret, :kind_of => String, :default => Chef::Config['encrypted_data_bag_secret']
-attribute :data_bag_type, :kind_of => String, :equal_to => ['unencrypted', 'encrypted', 'vault'], :default => 'encrypted'
+attribute :data_bag_type, :kind_of => String, :equal_to => ['unencrypted', 'encrypted', 'vault', 'hashicorp-vault'], :default => 'encrypted'
 attribute :search_id, :kind_of => String, :name_attribute => true
 attribute :ignore_missing, :kind_of => [TrueClass, FalseClass], :default => false
 
@@ -65,6 +65,9 @@ attribute :group, :kind_of => String, :default => 'root'
 
 # Cookbook to search for blank.erb template
 attribute :cookbook, :kind_of => String, :default => 'certificate'
+
+attribute :hashicorp_vault_address, :kind_of => String, :default => 'https://127.0.0.1:8200'
+attribute :hashicorp_vault_token, :kind_of => String, :default => 'abcd-1234'
 
 # Accesors for determining where files should be placed
 def certificate


### PR DESCRIPTION
Adds another possible value for `data_bag_type` which supports hashicorp vault.

It also adds two attributes:

  - hashicorp_vault_address
  - hashicorp_vault_token

To configure which server and which token to use when talking to the vault server.

The pull request has no tests for it, because kitchen does not allow multi-vm tests.

To test it I launched a docker with vault:
  - `docker run --cap-add=IPC_LOCK -d --name=dev-vault -p 8200:8200 vault`
  - Copied the root token from `docker logs <image-id>`
  - Made a POST using Postman to:
     - URL: http://localhost:8200/v1/secret/certificates
     - Headers:
        - X-Vault-Token=`<root-token>`
     - Body in application/json:
        ```
        {
          "id": "a name",
          "cert": "-----BEGIN CERTIFICATE-----\n<the certificate>\n-----END CERTIFICATE-----",
          "key": "-----BEGIN PRIVATE KEY-----\n<the certificate>\n-----END PRIVATE KEY-----",
          "chain": "-----BEGIN CERTIFICATE-----\n<the certificate>\n-----END CERTIFICATE-----"
        }
        ```
  - Created a suite:
    ```
    - name: hashicorp-vault
      run_list: ["recipe[certificate::manage_by_attributes]"]
      attributes:
        certificate: [
          test: {
            data_bag_type: 'hashicorp-vault',
            nginx_cert: true,
            cert_file: "test.pem",
            key_file: "test.key",
            search_id: "secrets/certificates",
            hashicorp_vault_token: <the root token>
          }
        ]
    ```
  - `kitchen test hashicorp-vault`

