### PR TITLE
Fix cert_path usage when using create_subfolders

### DIFF
--- a/.delivery/project.toml
+++ b/.delivery/project.toml
@@ -1,9 +1,0 @@
-[local_phases]
-unit = "rspec spec/"
-lint = 'cookstyle --display-cop-names --extra-details'
-syntax = "echo skipping"
-provision = "echo skipping"
-deploy = "echo skipping"
-smoke = "echo skipping"
-functional = "echo skipping"
-cleanup = "echo skipping"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,34 +8,11 @@ name: ci
       - main
 
 jobs:
-  delivery:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@main
-      - name: Run Chef Delivery
-        uses: actionshub/chef-delivery@main
-        env:
-          CHEF_LICENSE: accept-no-persist
-
-  yamllint:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@main
-      - name: Run yaml Lint
-        uses: actionshub/yamllint@main
-
-  mdl:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Check out code
-        uses: actions/checkout@main
-      - name: Run Markdown Lint
-        uses: actionshub/markdownlint@main
+  lint-unit:
+    uses: sous-chefs/.github/.github/workflows/lint-unit.yml@0.0.3
 
   dokken:
-    needs: [delivery]
+    needs: 'lint-unit'
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,12 @@ jobs:
     strategy:
       matrix:
         os:
+          - almalinux-8
           - centos-7
-          - centos-8
-          - debian-9
+          - centos-stream-8
           - debian-10
+          - debian-11
+          - rockylinux-8
           - ubuntu-1804
           - ubuntu-2004
         suite:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 This file is used to list changes made in each version of the certificate cookbook.
 
+## Unreleased
+
+- Fix `cert_path` usage when using `create_subfolders`
+
 ## 2.0.2 - *2021-08-30*
 
 - Standardise files with files in sous-chefs/repo-management

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ This file is used to list changes made in each version of the certificate cookbo
 
 - Fix `cert_path` usage when using `create_subfolders`
 - Remove delivery and move to calling RSpec directly via a reusable workflow
+- Update tested platforms
 
 ## 2.0.2 - *2021-08-30*
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This file is used to list changes made in each version of the certificate cookbo
 ## Unreleased
 
 - Fix `cert_path` usage when using `create_subfolders`
+- Remove delivery and move to calling RSpec directly via a reusable workflow
 
 ## 2.0.2 - *2021-08-30*
 

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -12,53 +12,53 @@ transport:
 provisioner:
   name: dokken
 
-  platforms:
-    - name: almalinux-8
-      driver:
-        image: dokken/almalinux-8
-        pid_one_command: /usr/lib/systemd/systemd
+platforms:
+  - name: almalinux-8
+    driver:
+      image: dokken/almalinux-8
+      pid_one_command: /usr/lib/systemd/systemd
 
-    - name: amazonlinux-2
-      driver:
-        image: dokken/amazonlinux-2
-        pid_one_command: /usr/lib/systemd/systemd
+  - name: amazonlinux-2
+    driver:
+      image: dokken/amazonlinux-2
+      pid_one_command: /usr/lib/systemd/systemd
 
-    - name: debian-10
-      driver:
-        image: dokken/debian-10
-        pid_one_command: /bin/systemd
+  - name: debian-10
+    driver:
+      image: dokken/debian-10
+      pid_one_command: /bin/systemd
 
-    - name: debian-11
-      driver:
-        image: dokken/debian-11
-        pid_one_command: /bin/systemd
+  - name: debian-11
+    driver:
+      image: dokken/debian-11
+      pid_one_command: /bin/systemd
 
-    - name: centos-7
-      driver:
-        image: dokken/centos-7
-        pid_one_command: /usr/lib/systemd/systemd
+  - name: centos-7
+    driver:
+      image: dokken/centos-7
+      pid_one_command: /usr/lib/systemd/systemd
 
-    - name: centos-stream-8
-      driver:
-        image: dokken/centos-stream-8
-        pid_one_command: /usr/lib/systemd/systemd
+  - name: centos-stream-8
+    driver:
+      image: dokken/centos-stream-8
+      pid_one_command: /usr/lib/systemd/systemd
 
-    - name: ubuntu-18.04
-      driver:
-        image: dokken/ubuntu-18.04
-        pid_one_command: /bin/systemd
+  - name: ubuntu-18.04
+    driver:
+      image: dokken/ubuntu-18.04
+      pid_one_command: /bin/systemd
 
-    - name: ubuntu-20.04
-      driver:
-        image: dokken/ubuntu-20.04
-        pid_one_command: /bin/systemd
+  - name: ubuntu-20.04
+    driver:
+      image: dokken/ubuntu-20.04
+      pid_one_command: /bin/systemd
 
-    - name: opensuse-leap-15
-      driver:
-        image: dokken/opensuse-leap-15
-        pid_one_command: /usr/lib/systemd/systemd
+  - name: opensuse-leap-15
+    driver:
+      image: dokken/opensuse-leap-15
+      pid_one_command: /usr/lib/systemd/systemd
 
-    - name: rockylinux-8
-      driver:
-        image: dokken/rockylinux-8
-        pid_one_command: /usr/lib/systemd/systemd
+  - name: rockylinux-8
+    driver:
+      image: dokken/rockylinux-8
+      pid_one_command: /usr/lib/systemd/systemd

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -13,50 +13,52 @@ provisioner:
   name: dokken
 
   platforms:
+    - name: almalinux-8
+      driver:
+        image: dokken/almalinux-8
+        pid_one_command: /usr/lib/systemd/systemd
+
     - name: amazonlinux-2
       driver:
         image: dokken/amazonlinux-2
         pid_one_command: /usr/lib/systemd/systemd
 
-    - name: debian-9
-      driver:
-        image: dokken/debian-9
-        pid_one_command: /bin/systemd
-        intermediate_instructions:
-          - RUN /usr/bin/apt-get update
-
     - name: debian-10
       driver:
         image: dokken/debian-10
         pid_one_command: /bin/systemd
-        intermediate_instructions:
-          - RUN /usr/bin/apt-get update
+
+    - name: debian-11
+      driver:
+        image: dokken/debian-11
+        pid_one_command: /bin/systemd
 
     - name: centos-7
       driver:
         image: dokken/centos-7
         pid_one_command: /usr/lib/systemd/systemd
 
-    - name: centos-8
+    - name: centos-stream-8
       driver:
-        image: dokken/centos-8
+        image: dokken/centos-stream-8
         pid_one_command: /usr/lib/systemd/systemd
 
     - name: ubuntu-18.04
       driver:
         image: dokken/ubuntu-18.04
         pid_one_command: /bin/systemd
-        intermediate_instructions:
-          - RUN /usr/bin/apt-get update
 
     - name: ubuntu-20.04
       driver:
         image: dokken/ubuntu-20.04
         pid_one_command: /bin/systemd
-        intermediate_instructions:
-          - RUN /usr/bin/apt-get update
 
     - name: opensuse-leap-15
       driver:
         image: dokken/opensuse-leap-15
-        pid_one_command: /bin/systemd
+        pid_one_command: /usr/lib/systemd/systemd
+
+    - name: rockylinux-8
+      driver:
+        image: dokken/rockylinux-8
+        pid_one_command: /usr/lib/systemd/systemd

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,8 +3,8 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_zero
-  product_name: chef
+  name: chef_infra
+  product_name: <%= ENV['CHEF_PRODUCT_NAME'] || 'chef' %>
   chef_license: accept-no-persist
   enforce_idempotency: true
   multiple_converge: 2
@@ -16,12 +16,14 @@ verifier:
   name: inspec
 
 platforms:
+  - name: almalinux-8
   - name: amazonlinux-2
   - name: centos-7
-  - name: centos-8
-  - name: debian-9
+  - name: centos-stream-8
   - name: debian-10
+  - name: debian-11
   - name: opensuse-leap-15
+  - name: rockylinux-8
   - name: ubuntu-18.04
   - name: ubuntu-20.04
 

--- a/resources/manage.rb
+++ b/resources/manage.rb
@@ -123,14 +123,14 @@ action :create do
   next if cert_data.nil?
 
   if new_resource.create_subfolders
-    directory ::File.join(new_resource.default_cert_path, 'certs') do
+    directory ::File.join(new_resource.cert_path, 'certs') do
       owner new_resource.owner
       group new_resource.group
       mode '755'
       recursive true
     end
 
-    directory ::File.join(new_resource.default_cert_path, 'private') do
+    directory ::File.join(new_resource.cert_path, 'private') do
       owner new_resource.owner
       group new_resource.group
       mode '750'


### PR DESCRIPTION
- Fix cert_path usage when using create_subfolders
- Remove delivery and move to calling RSpec directly via a reusable workflow
- Update tested platforms
