### PR TITLE
chore: migrate to Policyfile

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -18,12 +18,12 @@
 - `libraries/` - Library helpers to assist with the cookbook. May contain multiple files depending on complexity of the cookbook.
 - `templates/` - ERB templates that may be used in the cookbook
 - `files/` - files that may be used in the cookbook
-- `metadata.rb`, `Berksfile` - Cookbook metadata and dependencies
+- `metadata.rb`, `Policyfile.rb` - Cookbook metadata and dependency resolution
 
 ## Build and Test System
 
 ### Environment Setup
-**MANDATORY:** Install Chef Workstation first - provides chef, berks, cookstyle, kitchen tools.
+**MANDATORY:** Install Chef Workstation first - provides chef, cookstyle, kitchen, and Policyfile tooling.
 
 ### Essential Commands (strict order)
 ```bash

--- a/chefignore
+++ b/chefignore
@@ -96,7 +96,6 @@ Gemfile.lock
 
 # Policyfile #
 ##############
-Policyfile.rb
 Policyfile.lock.json
 
 # Documentation #

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,12 +3,13 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_infra
+  name: policyfile_zero
   product_name: <%= ENV['CHEF_PRODUCT_NAME'] || 'chef' %>
   chef_license: accept-no-persist
   enforce_idempotency: true
   multiple_converge: 2
   deprecations_as_errors: true
+  policyfile: Policyfile.rb
   data_bags_path: test/integration/data_bags
   encrypted_data_bag_secret_key_path: test/integration/encrypted_data_bag_secret
 
@@ -33,24 +34,32 @@ suites:
   - name: default
     run_list:
       - recipe[test::default]
+    provisioner:
+      named_run_list: default
     verifier:
       inspec_tests:
         - test/integration/default
   - name: unencrypted
     run_list:
       - recipe[test::unencrypted]
+    provisioner:
+      named_run_list: unencrypted
     verifier:
       inspec_tests:
         - test/integration/default
   - name: encrypted
     run_list:
       - recipe[test::encrypted]
+    provisioner:
+      named_run_list: encrypted
     verifier:
       inspec_tests:
         - test/integration/default
   - name: none
     run_list:
       - recipe[test::none]
+    provisioner:
+      named_run_list: none
     verifier:
       inspec_tests:
         - test/integration/default


### PR DESCRIPTION
## Summary
- Replace Berksfile dependency resolution with Policyfile.rb
- Update ChefSpec and Kitchen to use Policyfile resolution
- Update Copilot instructions/setup for chef install Policyfile.rb

## Verification
- chef install Policyfile.rb
- cookstyle --no-server --cache-root /private/tmp/rubocop_cache
- markdownlint-cli2 "**/*.md"
- embedded rspec --format progress
- git diff --check
- kitchen list
- KITCHEN_LOCAL_YAML=kitchen.dokken.yml kitchen list